### PR TITLE
Initialization throws MaxRangeError with cytoscape 3.2.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ http://www.sentences.com/docs/other_docs/AMD.pdf
 
 ## Dependencies
 
-* Cytoscape.js ^3.2.0
+* Cytoscape.js >=3.3.2
 
 
 ## Usage instructions

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "webpack": "^4.29.0"
   },
   "peerDependencies": {
-    "cytoscape": "^3.2.0"
+    "cytoscape": ">=3.3.2"
   }
 }


### PR DESCRIPTION
Bumping listed dependency in README to >=3.3.2 because:
```
**0.3.1** -- Jan 15, 2019

* Make use of Cytoscape 3.3.2 (edge point fix, https://github.com/cytoscape/cytoscape.js/issues/2250)
```
which I assume was the culprit.